### PR TITLE
Better support for hbs files (web-mode)

### DIFF
--- a/init.el
+++ b/init.el
@@ -103,6 +103,7 @@
 (require 'init-slime)
 (require 'init-common-lisp)
 (require 'init-kubernetes)
+(require 'init-web-mode)
 
 (when *spell-check-support-enabled*
   (require 'init-spelling))

--- a/lisp/init-html.el
+++ b/lisp/init-html.el
@@ -7,7 +7,6 @@
   (add-hook 'sgml-mode-hook (lambda () (tagedit-mode 1))))
 
 (add-auto-mode 'html-mode "\\.\\(jsp\\|tmpl\\)\\'")
-(add-auto-mode 'html-mode "\\.\\hbs")
 
 (add-hook 'html-mode-hook
           (lambda ()

--- a/lisp/init-web-mode.el
+++ b/lisp/init-web-mode.el
@@ -1,0 +1,6 @@
+(require-package 'web-mode)
+
+;; Associate hbs files with web-mode
+(add-to-list 'auto-mode-alist '("\\.hbs\\'" . web-mode))
+
+(provide 'init-web-mode)


### PR DESCRIPTION
Uses [web-mode](http://web-mode.org/) for `hbs` files. Might want to try this out before merging to see if we like it.